### PR TITLE
:wrench: upgrade linux builds to self-hosted option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node: ['12.x', '14.x', '16.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [[self-hosted, ubuntu-latest], windows-latest, macOS-latest]
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
~This adds a self-hosted runner for the linux portion of this to decrease runner/check times.~

Not merging. I'm moving quickly and forgot that GH runners aren't docker-containers and there's no way I'm maintaining versions of node + updates on the VM + allowing contributors to run a PR remotely on our servers. 🤦 
