### PR TITLE
:wrench: :question: workaround np limitation on first/init release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promo-button",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "license": "MIT",
   "author": "Jason R. Stevens, CFA",
   "main": "dist/index.js",


### PR DESCRIPTION
The np lib won't let me publish to 0.0.1 version without the package being 0.0.0 first. 

This PR changes the version back to 0.0.0.