### PR TITLE
Feature/add promo api auth

### DIFF
--- a/__tests__/lib/getToken.test.tsx
+++ b/__tests__/lib/getToken.test.tsx
@@ -1,0 +1,44 @@
+import jwt from 'jsonwebtoken';
+import { getToken } from '../../.';
+
+jest.setTimeout(10000);
+
+/**
+ * Encode (and sign) a given object as JWT.
+ *
+ * @param data object to encode in base64 and sign via HMAC and the given
+ *     passphrase
+ * @param passphrase string secret passphrase for producing the HMAC hash of the
+ *     data
+ * @returns string JWT token
+ */
+function encodeJwt(data: object, passphrase: string): string {
+  if (typeof data !== 'object')
+    throw new Error(
+      'data is not a JavaScript object. Do better next time, please.'
+    );
+  const token = jwt.sign(data, passphrase);
+  return token;
+}
+
+describe('getToken', () => {
+  const rightnow = Date.now();
+  let accessToken: any = {
+    sub: '',
+    iss: 'http://localhost:8000',
+    cid: 'IzJK43FlPjJX9oY2REZoj0iJOsPg',
+    aid: 'uWR2Nby08TMUiYURXR2wDZlNoFoi',
+    iat: rightnow,
+    exp: rightnow + 1800, // 30 minutes
+    scope: '',
+    token_type: 'Access',
+  };
+  const clientSecret = 'qK2FXA-hnuASPSFMNTQnQu3xdszaCeLlQ3rawYeliWr5SzGP'; // never do this in your client side js but this is safe due to it being a testing application alone
+
+  let accessTokenSigned: string = encodeJwt(accessToken, clientSecret);
+
+  it('returns a string', async () => {
+    let resultToken: string = await getToken(accessTokenSigned);
+    expect(typeof resultToken).toBe('string');
+  });
+});

--- a/__tests__/lib/getToken.test.tsx
+++ b/__tests__/lib/getToken.test.tsx
@@ -1,41 +1,16 @@
-import jwt from 'jsonwebtoken';
 import { getToken } from '../../.';
-
-jest.setTimeout(10000);
-
-/**
- * Encode (and sign) a given object as JWT.
- *
- * @param data object to encode in base64 and sign via HMAC and the given
- *     passphrase
- * @param passphrase string secret passphrase for producing the HMAC hash of the
- *     data
- * @returns string JWT token
- */
-function encodeJwt(data: object, passphrase: string): string {
-  if (typeof data !== 'object')
-    throw new Error(
-      'data is not a JavaScript object. Do better next time, please.'
-    );
-  const token = jwt.sign(data, passphrase);
-  return token;
-}
+import { generateAccessToken } from '../test-utils';
+jest.setTimeout(20000);
 
 describe('getToken', () => {
-  const rightnow = Date.now();
-  let accessToken: any = {
-    sub: '',
-    iss: 'http://localhost:8000',
-    cid: 'IzJK43FlPjJX9oY2REZoj0iJOsPg',
-    aid: 'uWR2Nby08TMUiYURXR2wDZlNoFoi',
-    iat: rightnow,
-    exp: rightnow + 1800, // 30 minutes
-    scope: '',
-    token_type: 'Access',
-  };
   const clientSecret = 'qK2FXA-hnuASPSFMNTQnQu3xdszaCeLlQ3rawYeliWr5SzGP'; // never do this in your client side js but this is safe due to it being a testing application alone
 
-  let accessTokenSigned: string = encodeJwt(accessToken, clientSecret);
+  let accessTokenSigned: string = generateAccessToken(
+    'http://localhost:3000',
+    'IzJK43FlPjJX9oY2REZoj0iJOsPg',
+    'uWR2Nby08TMUiYURXR2wDZlNoFoi',
+    clientSecret
+  );
 
   it('returns a string', async () => {
     let resultToken: string = await getToken(accessTokenSigned);

--- a/__tests__/lib/getToken.test.tsx
+++ b/__tests__/lib/getToken.test.tsx
@@ -1,6 +1,6 @@
 import { getToken } from '../../.';
 import { generateAccessToken } from '../test-utils';
-jest.setTimeout(20000);
+jest.setTimeout(40000);
 
 describe('getToken', () => {
   const clientSecret = 'qK2FXA-hnuASPSFMNTQnQu3xdszaCeLlQ3rawYeliWr5SzGP'; // never do this in your client side js but this is safe due to it being a testing application alone

--- a/__tests__/test-utils.tsx
+++ b/__tests__/test-utils.tsx
@@ -1,0 +1,64 @@
+import jwt from 'jsonwebtoken';
+/**
+ * Encode (and sign) a given object as JWT.
+ *
+ * @param data object to encode in base64 and sign via HMAC and the given
+ *     passphrase
+ * @param passphrase string secret passphrase for producing the HMAC hash of the
+ *     data
+ * @returns string JWT token
+ */
+function encodeJwt(data: object, passphrase: string): string {
+  if (typeof data !== 'object')
+    throw new Error(
+      'data is not a JavaScript object. Do better next time, please.'
+    );
+  const token = jwt.sign(data, passphrase);
+  return token;
+}
+
+interface PromoAccessTokenJwt {
+  sub: string;
+  iss: string;
+  cid: string;
+  aid: string;
+  iat: string | number;
+  exp: string | number;
+  scope: string;
+  token_type: string;
+}
+/**
+ * Given the issuer URL, clientId, appId, and clientSecret return a
+ * signed access token.
+ *
+ * @param issuer the URL for which this token should be valid and usable
+ * @param clientId the string clientId from the tincre.dev dashboard
+ * @param appId the string appId from the tincre.dev dashboard
+ * @param clientSecret the string clientSecret from the tincre.dev dashboard
+ * @param expiration optional expiration number in seconds; defaults to 30 min
+ * @returns string JWT signed with the clientSecret provided
+ */
+function generateAccessToken(
+  issuer: string,
+  clientId: string,
+  appId: string,
+  clientSecret: string,
+  expiration?: number
+) {
+  const timestamp = Date.now();
+  const exp = expiration ? timestamp + expiration : timestamp + 1800;
+  let accessToken: PromoAccessTokenJwt = {
+    sub: '',
+    iss: issuer,
+    cid: clientId,
+    aid: appId,
+    iat: timestamp,
+    exp: exp,
+    scope: '',
+    token_type: 'Access',
+  };
+
+  return encodeJwt(accessToken, clientSecret);
+}
+
+export { encodeJwt, generateAccessToken };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "dts build",
     "size": "size-limit",
     "start": "dts watch",
-    "test": "dts test --passWithNoTests"
+    "test": "dts test --passWithNoTests --coverage"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@tsconfig/create-react-app": "^1.0.2",
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^27.4.1",
+    "@types/jsonwebtoken": "^8.5.8",
     "@types/node": "^17.0.25",
     "@types/react": "^18.0.6",
     "@types/react-dom": "^18.0.2",
@@ -75,6 +76,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "identity-obj-proxy": "^3.0.0",
+    "jsonwebtoken": "^8.5.1",
     "postcss": "^8.4.12",
     "prettier": "^2.6.2",
     "react": "~17",
@@ -84,5 +86,8 @@
     "tailwindcss": "^3.0.24",
     "tslib": "^2.3.1",
     "typescript": "^4.6.3"
+  },
+  "dependencies": {
+    "cross-fetch": "^3.1.5"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { XIcon } from './icons';
 import ThreeWords from './ThreeWords';
 import { useScript } from './lib/useScript';
+import { getToken } from './lib/getToken';
 
 const Cloudinary = React.lazy(() => import('./Cloudinary'));
 export function HowItWorks() {
@@ -384,3 +385,5 @@ export function PromoButton({
     </div>
   );
 }
+
+export { getToken };

--- a/src/lib/getToken.tsx
+++ b/src/lib/getToken.tsx
@@ -1,0 +1,41 @@
+import fetch from 'cross-fetch';
+/**
+ * getToken
+ *
+ * Given a JWT encoded accessToken query the Tincre promo-api for
+ * a usable refresh token for application calls.
+ *
+ * This method decodes the jwt returned from the Tincre promo-api
+ * but as it is to be used on the client, _does not validate the jwt_.
+ *
+ * > :hot_pepper: :lock: Validating or encoding a JWT must be done on your backend, as they
+ * are signed with your `clientSecret` value from the dashboard.
+ *
+ * @param accessToken string JWT-encoded access token per
+ * https://tincre.dev/docs/guides/how-to-auth.
+ *
+ * @returns a usable refresh token you can store on the client.
+ */
+export async function getToken(accessToken: string): Promise<string> {
+  const url = 'https://promo.api.tincre.dev/token';
+  let refreshToken: string;
+  // Example POST method implementation:
+  // Default options are marked with *
+  console.debug(`getToken: Sending POST request to backend promo-api ${url}`);
+  const response = await fetch(url, {
+    method: 'POST', // *GET, POST, PUT, DELETE, etc.
+    mode: 'cors', // no-cors, *cors, same-origin
+    cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+    credentials: 'same-origin', // include, *same-origin, omit
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+      // 'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  });
+  console.debug(`getToken: awaiting response JSON`);
+  const responseToDecode: any = await response.json(); // parses JSON response into native JavaScript objects
+  refreshToken = responseToDecode?.token;
+  console.debug(`getToken: Retrieved refresh token: ${refreshToken}`);
+  return refreshToken;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,6 +1468,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/jsonwebtoken@^8.5.8":
+  version "8.5.8"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz#01b39711eb844777b7af1d1f2b4cf22fda1c0c44"
+  integrity sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -2166,6 +2173,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -2445,6 +2457,13 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -2836,6 +2855,13 @@ dts-cli@^1.5.1:
     tslib "^2.3.1"
     type-fest "^2.12.0"
     typescript "^4.5.5"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.4.84:
   version "1.4.107"
@@ -4642,6 +4668,22 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.2.tgz#6ab1e52c71dfc0c0707008a91729a9491fe9f76c"
@@ -4649,6 +4691,23 @@ jsonfile@^6.0.1:
   dependencies:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -4735,6 +4794,36 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -4744,6 +4833,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -4942,6 +5036,13 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5955,7 +6056,7 @@ sade@^1.8.1:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -6008,6 +6109,11 @@ semver@7.x, semver@^7.3.2, semver@^7.3.5:
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
@@ -6431,6 +6537,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-jest@^27.1.3:
   version "27.1.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
@@ -6648,6 +6759,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -6669,6 +6785,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
This adds the initial refresh token grabber and other utilities necessary for authentication with the [promo-api](https://tincre.dev/promo). 

In particular, it adds the `getToken` method to acquire a refresh token given an encoded access token. 

> :hot_pepper: :lock: Clients must sign this token via a backend endpoint or seed the application using a pre-generated access token from their Tincre.dev application dashboard. 

> :eyes: See [your dashboard](https://tincre.dev/dashboard) once logged in for more.