### PR TITLE
:wrench: :bug: fix package scoping bug to @tincre only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tincre/promo-button",
   "version": "0.0.2",
-  "scope": "@tincre/promo-button",
+  "scope": "@tincre",
   "license": "MIT",
   "author": "Jason R. Stevens, CFA",
   "main": "dist/index.js",


### PR DESCRIPTION
The `package.json` `scope` parameter was incorrect and this fixes it to `@tincre`. 