### PR TITLE
Add Tailwindcss Classes

### DIFF
--- a/example/react/index.tsx
+++ b/example/react/index.tsx
@@ -1,7 +1,7 @@
 import * as ReactDOM from 'react-dom';
 import 'react-app-polyfill/ie11';
-import { PromoButton } from '@tincre/promo-button';
-import './node_modules/@tincre/promo-button/dist/promo-button.esm.css'; 
+import { PromoButton } from '../../dist/promo-button.esm.js'//'@tincre/promo-button';
+import '../../dist/promo-button.esm.css'; 
 
 const App = () => {
   return (

--- a/example/react/index.tsx
+++ b/example/react/index.tsx
@@ -12,7 +12,7 @@ const App = () => {
       <PromoButton
         logoSrc=""
         words={['Real', 'Easy', 'Ads']}
-        shape="square"
+        shape="hero"
         email="jason@tincre.com"
         backend="my-backend-route"
       />

--- a/src/AdTitleInput.tsx
+++ b/src/AdTitleInput.tsx
@@ -11,7 +11,11 @@
  *
  * @param placeholder - the placeholder text for the HTML input tag.
  */
-export default function AdTitleInput({ placeholder }: { placeholder?: string }) {
+export default function AdTitleInput({
+  placeholder,
+}: {
+  placeholder?: string;
+}) {
   return (
     <div className="mt-0">
       <label htmlFor="adTitle" className="promo-button-ad-title-input-label">

--- a/src/AdTitleInput.tsx
+++ b/src/AdTitleInput.tsx
@@ -11,19 +11,19 @@
  *
  * @param placeholder - the placeholder text for the HTML input tag.
  */
-export default function NameInput({ placeholder }: { placeholder?: string }) {
+export default function AdTitleInput({ placeholder }: { placeholder?: string }) {
   return (
     <div className="mt-0">
-      <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+      <label htmlFor="adTitle" className="promo-button-ad-title-input-label">
         Ad title{' '}
-        <span className="text-xs italic text-muted">{`as you'd like it to display on your ads`}</span>
+        <span className="promo-button-ad-title-input-label-inner">{`as you'd like it to display on your ads`}</span>
       </label>
-      <div className="mt-1 rounded-md shadow-sm">
+      <div className="promo-button-ad-title-input-container">
         <input
           type="text"
-          name="name"
-          id="name"
-          className="block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 border-black focus:ring-border-black focus:border-transparent rounded-md"
+          name="adTitle"
+          id="adTitle"
+          className="promo-button-ad-title-input"
           placeholder={placeholder || `The Kool-Aid Man`}
           required
         />

--- a/src/Cloudinary.tsx
+++ b/src/Cloudinary.tsx
@@ -11,9 +11,9 @@ function getWidget(setFileImage: any) {
   if (typeof window.cloudinary === 'undefined') return null;
   let widget = window.cloudinary.createUploadWidget(
     {
-      cloudName: `b00st`,
-      uploadPreset: `uscb5ifq`,
-      folder: 'B00STButton',
+      cloudName: `b00st`, // upload cloudName value
+      uploadPreset: `uscb5ifq`, // TODO Update preseet values
+      folder: 'B00STButton', // TODO folder value
       multiple: true,
     },
     (error: any, result: any) => {

--- a/src/Cloudinary.tsx
+++ b/src/Cloudinary.tsx
@@ -48,7 +48,7 @@ export default function Cloudinary({
       <div className="mt-3" id="cloudinary-upload-widget">
         <label
           htmlFor="cloudinary-upload-widget"
-          className="mb-1 block text-sm font-medium text-gray-700"
+          className="promo-button-upload-button-label"
         >
           Upload an image or video
         </label>
@@ -56,7 +56,7 @@ export default function Cloudinary({
           <button
             type="button"
             id="cloudinary-upload-widget"
-            className="inline-flex justify-center w-full rounded-md border border-black shadow-sm px-4 py-2 bg-gray-50 text-base font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-gray-900 focus:border-transparent sm:text-sm"
+            className="promo-button-upload-button"
             onClick={() => showWidget(widget)}
           >
             Ad creative upload tool

--- a/src/RangeInput.tsx
+++ b/src/RangeInput.tsx
@@ -28,13 +28,13 @@ export default function RangeInput({ rangeVal }: { rangeVal?: number }) {
     <div className="mt-3">
       <label
         htmlFor="budget"
-        className="block text-sm font-medium text-gray-700"
+        className="promo-button-range-input-label"
       >
         {`Budget: $${rangeval}`}
       </label>
-      <div className="mt-1 rounded-md">
+      <div className="promo-button-range-input-container">
         <input
-          className="block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 text-black focus:ring-border-black hover:border-transparent rounded-md"
+          className="promo-button-range-input"
           type="range"
           name="budget"
           id="budget"

--- a/src/RangeInput.tsx
+++ b/src/RangeInput.tsx
@@ -26,10 +26,7 @@ export default function RangeInput({ rangeVal }: { rangeVal?: number }) {
   const maxSpend = 10000;
   return (
     <div className="mt-3">
-      <label
-        htmlFor="budget"
-        className="promo-button-range-input-label"
-      >
+      <label htmlFor="budget" className="promo-button-range-input-label">
         {`Budget: $${rangeval}`}
       </label>
       <div className="promo-button-range-input-container">

--- a/src/RealEasyLogo.tsx
+++ b/src/RealEasyLogo.tsx
@@ -58,10 +58,7 @@ export default function RealEasyLogo({
     `Run awesome, epic, and cross-platform ads with a button press! Brought to you from Promo by tincre.dev.`;
 
   return (
-    <div
-      className="promo-button-modal-logo"
-      id="promo-modal-logo"
-    >
+    <div className="promo-button-modal-logo" id="promo-modal-logo">
       <div className="inline-flex justify-center items-center content-center text-xl text-red-700 font-semibold">
         <RealEasyImage
           height={40}

--- a/src/RealEasyLogo.tsx
+++ b/src/RealEasyLogo.tsx
@@ -59,7 +59,7 @@ export default function RealEasyLogo({
 
   return (
     <div
-      className="my-2 lg:my-5 relative flex justify-center content-center items-center"
+      className="promo-button-modal-logo"
       id="promo-modal-logo"
     >
       <div className="inline-flex justify-center items-center content-center text-xl text-red-700 font-semibold">

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -51,16 +51,16 @@ export default function TextInput({ placeholder }: { placeholder?: string }) {
     <div className="mt-3">
       <label
         htmlFor="target"
-        className="block text-sm font-medium text-gray-700"
+        className="promo-button-target-link-label"
       >
         Target link for your ads
       </label>
-      <div className="mt-1 relative rounded-md shadow-sm">
+      <div className="promo-button-target-link-input-container">
         <input
           type="url"
           name="target"
           id="target"
-          className="block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 border-black focus:ring-border-black focus:border-transparent rounded-md"
+          className="promo-button-target-link-input"
           placeholder={
             placeholder || 'https://www.youtube.com/watch?v=KfL1VCv2kCI'
           }

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -49,10 +49,7 @@ export default function TextInput({ placeholder }: { placeholder?: string }) {
   let [isChanging, setIsChanging] = useState<boolean | null | undefined>(null);
   return (
     <div className="mt-3">
-      <label
-        htmlFor="target"
-        className="promo-button-target-link-label"
-      >
+      <label htmlFor="target" className="promo-button-target-link-label">
         Target link for your ads
       </label>
       <div className="promo-button-target-link-input-container">

--- a/src/default.css
+++ b/src/default.css
@@ -10,6 +10,7 @@
  * class names below.
  */
 @layer components { 
+
   .promo-button-main {
     @apply rounded-md inline-block min-w-[6rem] min-h-[6rem] px-3 py-2 max-w-[12rem] max-h-[12rem] md:py-3 md:px-3 md:mr-2 uppercase leading-none text-white bg-black hover:bg-gray-100 shadow
   }
@@ -27,11 +28,11 @@
   }
 
   .promo-button-image-upload-error {
-    @apply text-sm font-medium italic text-indigo-700 mb-2
+    @apply text-sm font-medium italic text-brand mb-2
   }
 
   .promo-button-target-link-error {
-    @apply text-sm font-medium italic text-indigo-700 mb-2
+    @apply text-sm font-medium italic text-brand mb-2
   }
 
   .promo-button-close-icon-outer {
@@ -66,7 +67,7 @@
     @apply text-sm italic text-gray-500
   }
   .promo-button-dialog-submission-button {
-    @apply inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-700 antialiased text-lg sm:text-base font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 hover:text-black 
+    @apply inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-brand antialiased text-lg sm:text-base font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand hover:text-black 
   }
   .promo-button-dialog-submission-button-disabled {
     @apply disabled:bg-gray-800
@@ -78,13 +79,13 @@
     @apply text-xs italic text-gray-300
   }
   .promo-button-ad-title-input {
-    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 border-black focus:border-transparent rounded-md
+    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand border-black focus:border-transparent rounded-md
   }
   .promo-button-ad-title-input-container {
     @apply mt-1 rounded-md shadow-sm
   }
   .promo-button-target-link-input {
-    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 border-black focus:border-transparent rounded-md
+    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand border-black focus:border-transparent rounded-md
   }
   .promo-button-target-link-input-container {
     @apply mt-1 relative rounded-md shadow-sm
@@ -97,13 +98,13 @@
     @apply block text-sm font-medium text-gray-700
   }
   .promo-button-range-input {
-    @apply block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 text-black hover:border-transparent rounded-md
+    @apply block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand text-black hover:border-transparent rounded-md
   }
   .promo-button-range-input-container { 
     @apply mt-1 rounded-md
   }
   .promo-button-upload-button {
-    @apply inline-flex justify-center w-full rounded-md border border-black shadow-sm px-4 py-2 bg-gray-50 text-base font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 hover:text-gray-900 focus:border-transparent sm:text-sm
+    @apply inline-flex justify-center w-full rounded-md border border-black shadow-sm px-4 py-2 bg-gray-50 text-base font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand hover:text-gray-900 focus:border-transparent sm:text-sm
   }
   .promo-button-upload-button-label {
     @apply mb-1 block text-sm font-medium text-gray-700

--- a/src/default.css
+++ b/src/default.css
@@ -83,4 +83,13 @@
   .promo-button-ad-title-input-container {
     @apply mt-1 rounded-md shadow-sm
   }
+  .promo-button-target-link-input {
+    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 border-black focus:border-transparent rounded-md
+  }
+  .promo-button-target-link-input-container {
+    @apply mt-1 relative rounded-md shadow-sm
+  }
+  .promo-button-target-link-label {
+    @apply block text-sm font-medium text-gray-700
+  }
 }

--- a/src/default.css
+++ b/src/default.css
@@ -27,11 +27,11 @@
   }
 
   .promo-button-image-upload-error {
-    @apply text-sm font-medium italic text-red-700 mb-2
+    @apply text-sm font-medium italic text-indigo-700 mb-2
   }
 
   .promo-button-target-link-error {
-    @apply text-sm font-medium italic text-red-700 mb-2
+    @apply text-sm font-medium italic text-indigo-700 mb-2
   }
 
   .promo-button-close-icon-outer {
@@ -66,7 +66,7 @@
     @apply text-sm italic text-gray-500
   }
   .promo-button-dialog-submission-button {
-    @apply inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-700 antialiased text-lg sm:text-base font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-black 
+    @apply inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-700 antialiased text-lg sm:text-base font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 hover:text-black 
   }
   .promo-button-dialog-submission-button-disabled {
     @apply disabled:bg-gray-800
@@ -78,13 +78,13 @@
     @apply text-xs italic text-gray-300
   }
   .promo-button-ad-title-input {
-    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 border-black focus:border-transparent rounded-md
+    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 border-black focus:border-transparent rounded-md
   }
   .promo-button-ad-title-input-container {
     @apply mt-1 rounded-md shadow-sm
   }
   .promo-button-target-link-input {
-    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 border-black focus:border-transparent rounded-md
+    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 border-black focus:border-transparent rounded-md
   }
   .promo-button-target-link-input-container {
     @apply mt-1 relative rounded-md shadow-sm
@@ -97,13 +97,13 @@
     @apply block text-sm font-medium text-gray-700
   }
   .promo-button-range-input {
-    @apply block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 text-black hover:border-transparent rounded-md
+    @apply block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 text-black hover:border-transparent rounded-md
   }
   .promo-button-range-input-container { 
     @apply mt-1 rounded-md
   }
   .promo-button-upload-button {
-    @apply inline-flex justify-center w-full rounded-md border border-black shadow-sm px-4 py-2 bg-gray-50 text-base font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-gray-900 focus:border-transparent sm:text-sm
+    @apply inline-flex justify-center w-full rounded-md border border-black shadow-sm px-4 py-2 bg-gray-50 text-base font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-700 hover:text-gray-900 focus:border-transparent sm:text-sm
   }
   .promo-button-upload-button-label {
     @apply mb-1 block text-sm font-medium text-gray-700

--- a/src/default.css
+++ b/src/default.css
@@ -25,4 +25,22 @@
   .promo-button-square {
     @apply promo-button-main
   }
+
+  .promo-button-image-upload-error {
+    @apply text-sm font-medium italic text-red-700 mb-2
+  }
+
+  .promo-button-target-link-error {
+    @apply text-sm font-medium italic text-red-700 mb-2
+  }
+
+  .promo-button-close-icon-outer {
+    @apply block absolute top-0 right-0 pt-4 pr-4
+  }
+  .promo-button-close-icon-inner {
+    @apply bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-transparent
+  }
+  .promo-button-close-icon-size {
+    @apply h-6 w-6
+  }
 }

--- a/src/default.css
+++ b/src/default.css
@@ -71,5 +71,16 @@
   .promo-button-dialog-submission-button-disabled {
     @apply disabled:bg-gray-800
   }
-  
+  .promo-button-ad-title-input-label {
+    @apply block text-sm font-medium text-gray-700
+  }
+  .promo-button-ad-title-input-label-inner {
+    @apply text-xs italic text-gray-300
+  }
+  .promo-button-ad-title-input {
+    @apply block w-full sm:text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 border-black focus:border-transparent rounded-md
+  }
+  .promo-button-ad-title-input-container {
+    @apply mt-1 rounded-md shadow-sm
+  }
 }

--- a/src/default.css
+++ b/src/default.css
@@ -50,4 +50,13 @@
   .promo-button-dialog-inner {
     @apply flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0
   }
+  .promo-button-text {
+    @apply mx-auto uppercase italic text-base font-bold subpixel-antialiased my-auto
+  }
+  .promo-button-form-container { 
+    @apply inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6
+  }
+  .promo-button-modal-logo {
+    @apply px-12 my-2 lg:my-5 relative flex justify-center content-center items-center
+  }
 }

--- a/src/default.css
+++ b/src/default.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
+
 @tailwind utilities;
+
+
+/* promo-button custom css 
+ *
+ * Modify this section as you see fit in your own css files, using the
+ * class names below.
+ */
+@layer components { 
+  .promo-button-main {
+    @apply rounded-md group inline-block min-w-24 min-h-24 px-3 py-2 max-w-48 max-h-48 md:py-3 md:px-3 md:mr-2 uppercase leading-none text-white font-thinner bg-black hover:bg-gray-100 shadow
+  }
+  .promo-button-hero {
+    @apply inline-block px-24 py-24 uppercase leading-none text-white bg-black hover:bg-gray-100 rounded-md shadow
+  }
+  .promo-button-circle {
+    @apply promo-button-main rounded-full
+  }
+  .promo-button-plain {
+    @apply promo-button-main rounded-md py-2 px-6 md:py-3
+  }
+  .promo-button-square {
+    @apply promo-button-main
+  }
+}

--- a/src/default.css
+++ b/src/default.css
@@ -97,9 +97,15 @@
     @apply block text-sm font-medium text-gray-700
   }
   .promo-button-range-input {
-    @apply block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 text-black focus:ring-border-black hover:border-transparent rounded-md
+    @apply block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 text-black hover:border-transparent rounded-md
   }
   .promo-button-range-input-container { 
     @apply mt-1 rounded-md
+  }
+  .promo-button-upload-button {
+    @apply inline-flex justify-center w-full rounded-md border border-black shadow-sm px-4 py-2 bg-gray-50 text-base font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-gray-900 focus:border-transparent sm:text-sm
+  }
+  .promo-button-upload-button-label {
+    @apply mb-1 block text-sm font-medium text-gray-700
   }
 }

--- a/src/default.css
+++ b/src/default.css
@@ -92,4 +92,14 @@
   .promo-button-target-link-label {
     @apply block text-sm font-medium text-gray-700
   }
+  .promo-button-range-input-label {
+  
+    @apply block text-sm font-medium text-gray-700
+  }
+  .promo-button-range-input {
+    @apply block w-full pl-16 sm:pl-14 sm:text-sm border-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 text-black focus:ring-border-black hover:border-transparent rounded-md
+  }
+  .promo-button-range-input-container { 
+    @apply mt-1 rounded-md
+  }
 }

--- a/src/default.css
+++ b/src/default.css
@@ -43,4 +43,11 @@
   .promo-button-close-icon-size {
     @apply h-6 w-6
   }
+
+  .promo-button-dialog-outer {
+    @apply fixed z-10 inset-0 overflow-y-auto
+  }
+  .promo-button-dialog-inner {
+    @apply flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0
+  }
 }

--- a/src/default.css
+++ b/src/default.css
@@ -11,7 +11,7 @@
  */
 @layer components { 
   .promo-button-main {
-    @apply rounded-md group inline-block min-w-24 min-h-24 px-3 py-2 max-w-48 max-h-48 md:py-3 md:px-3 md:mr-2 uppercase leading-none text-white font-thinner bg-black hover:bg-gray-100 shadow
+    @apply rounded-md inline-block min-w-[6rem] min-h-[6rem] px-3 py-2 max-w-[12rem] max-h-[12rem] md:py-3 md:px-3 md:mr-2 uppercase leading-none text-white bg-black hover:bg-gray-100 shadow
   }
   .promo-button-hero {
     @apply inline-block px-24 py-24 uppercase leading-none text-white bg-black hover:bg-gray-100 rounded-md shadow

--- a/src/default.css
+++ b/src/default.css
@@ -59,4 +59,17 @@
   .promo-button-modal-logo {
     @apply px-12 my-2 lg:my-5 relative flex justify-center content-center items-center
   }
+  .promo-button-dialog-title-text {
+    @apply text-lg leading-6 font-medium text-gray-900
+  }
+  .promo-button-dialog-subtitle-text {
+    @apply text-sm italic text-gray-500
+  }
+  .promo-button-dialog-submission-button {
+    @apply inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-700 antialiased text-lg sm:text-md font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-black 
+  }
+  .promo-button-dialog-submission-button-disabled {
+    @apply disabled:bg-gray-800
+  }
+  
 }

--- a/src/default.css
+++ b/src/default.css
@@ -66,7 +66,7 @@
     @apply text-sm italic text-gray-500
   }
   .promo-button-dialog-submission-button {
-    @apply inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-700 antialiased text-lg sm:text-md font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-black 
+    @apply inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-700 antialiased text-lg sm:text-base font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-black 
   }
   .promo-button-dialog-submission-button-disabled {
     @apply disabled:bg-gray-800

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -334,7 +334,9 @@ export function PromoButton({
                                 type="submit"
                                 disabled={isSubmitting && fileImage}
                                 className={`${
-                                  !isSubmitting ? '' : 'promo-button-dialog-submission-button-disabled'
+                                  !isSubmitting
+                                    ? ''
+                                    : 'promo-button-dialog-submission-button-disabled'
                                 } promo-button-dialog-submission-button`}
                               >
                                 {!isSubmitting ? (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -257,11 +257,11 @@ export function PromoButton({
                 as="div"
                 initialFocus={artistNameInputRef}
                 static
-                className="fixed z-10 inset-0 overflow-y-auto"
+                className="promo-button-dialog-outer"
                 open={isOpen}
                 onClose={() => setIsOpen(!isOpen)}
               >
-                <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+                <div className="promo-button-dialog-inner">
                   <Transition.Child
                     as={Fragment}
                     enter="ease-out duration-300"
@@ -271,7 +271,7 @@ export function PromoButton({
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                   >
-                    <Dialog.Overlay className="rounded-md fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+                    <Dialog.Overlay className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
                   </Transition.Child>
 
                   {/* This element is to trick the browser into centering the modal contents. */}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -244,7 +244,7 @@ export function PromoButton({
         }}
         className={mainButtonClassName()}
       >
-        <span className="mx-auto uppercase italic text-md font-bold subpixel-antialiased my-auto">
+        <span className="promo-button-text">
           <ThreeWords
             {...{
               words: buttonTextArray,
@@ -292,12 +292,10 @@ export function PromoButton({
                   >
                     <form
                       onSubmit={submitCampaign}
-                      className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
+                      className="promo-button-form-container"
                     >
                       <div>
-                        <div className="px-12">
-                          <RealEasyLogo src={logoSrc} />
-                        </div>
+                        <RealEasyLogo src={logoSrc} />
                         <div className="mt-3 text-center sm:mt-5">
                           <Dialog.Title
                             as="h3"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -171,19 +171,7 @@ export function PromoButton({
   let [targetLinkError, setTargetLinkError] = useState(false);
   let artistNameInputRef = useRef(null);
   useScript('https://widget.cloudinary.com/v2.0/global/all.js');
-  let mainButtonStyle: any = null;
-  if (typeof shape !== 'undefined') {
-    if (
-      shape !== 'square' &&
-      shape !== 'circle' &&
-      shape !== 'plain' &&
-      shape !== 'hero'
-    )
-      return null;
-    mainButtonStyle = shape;
-  } else {
-    mainButtonStyle = 'square';
-  }
+
   let buttonTextArray;
   if (typeof words === 'undefined') {
     buttonTextArray = ['Real', 'Easy', 'Ads!'];
@@ -191,18 +179,13 @@ export function PromoButton({
     buttonTextArray = words;
   }
   const mainButtonClassName = () => {
-    let staticStyle = 'rounded-md';
-    if (mainButtonStyle === 'square') {
-      staticStyle = 'rounded-md';
-    } else if (mainButtonStyle === 'circle') {
-      staticStyle = 'rounded-full';
-    } else if (mainButtonStyle === 'plain') {
-      staticStyle = 'rounded-md py-2 px-6 md:py-3 md:px-6';
-    } else if (mainButtonStyle === 'hero') {
-      return `group inline-block px-24 py-24 uppercase leading-none text-white font-thinner bg-black hover:bg-gray-100 rounded-md shadow`;
+    if (typeof shape !== 'string') {
+      return 'promo-button-main';
     }
-
-    return `group inline-block min-w-24 min-h-24 px-3 py-2 max-w-48 max-h-48 md:py-3 md:px-3 md:mr-2 uppercase leading-none text-white font-thinner bg-black hover:bg-gray-100 ${staticStyle} shadow`;
+    if (shape !== 'hero') {
+      return `promo-button-${shape}`;
+    }
+    return `group promo-button-hero`;
   };
 
   const submitCampaign = async (event: any) => {
@@ -266,7 +249,10 @@ export function PromoButton({
       >
         <span className="mx-auto uppercase italic text-md font-bold subpixel-antialiased my-auto">
           <ThreeWords
-            {...{ words: buttonTextArray, isHero: mainButtonStyle === 'hero' }}
+            {...{
+              words: buttonTextArray,
+              isHero: mainButtonClassName() === 'group promo-button-hero',
+            }}
           />
           <div>
             <Transition.Root show={isOpen} as={Fragment}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -299,13 +299,13 @@ export function PromoButton({
                         <div className="mt-3 text-center sm:mt-5">
                           <Dialog.Title
                             as="h3"
-                            className="text-lg leading-6 font-medium text-gray-900"
+                            className="promo-button-dialog-title-text"
                           >
                             {!isSubmitted ? `Start a campaign` : `Success!`}{' '}
                             <CloseButtonXIcon onClose={setIsOpen} />
                           </Dialog.Title>
                           <div className="mt-2">
-                            <p className="text-sm italic text-gray-500">
+                            <p className="promo-button-dialog-subtitle-text">
                               {!isSubmitted
                                 ? `We need just a few items to start.`
                                 : `Check your email for a link to fund your campaign.`}
@@ -334,8 +334,8 @@ export function PromoButton({
                                 type="submit"
                                 disabled={isSubmitting && fileImage}
                                 className={`${
-                                  !isSubmitting ? '' : 'disabled:bg-gray-800'
-                                } inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-700 antialiased text-lg sm:text-md font-bold tracking-wide text-white hover:bg-gray-200 hover:text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 hover:text-black `}
+                                  !isSubmitting ? '' : 'promo-button-dialog-submission-button-disabled'
+                                } promo-button-dialog-submission-button`}
                               >
                                 {!isSubmitting ? (
                                   <svg

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -120,7 +120,7 @@ export function TeamEmail({
 export function ImageUploadError() {
   return (
     <div>
-      <p className="text-sm font-medium italic text-red-700 mb-2">
+      <p className="promo-button-image-upload-error">
         Please upload an image or video in order to run your campaign.
       </p>
     </div>
@@ -129,7 +129,7 @@ export function ImageUploadError() {
 export function TargetLinkError() {
   return (
     <div>
-      <p className="text-sm font-medium italic text-red-700 mb-2">
+      <p className="promo-button-target-link-error">
         It appears the submitted link is not a valid url. Please try again.
       </p>
     </div>
@@ -137,14 +137,14 @@ export function TargetLinkError() {
 }
 export function CloseButtonXIcon({ onClose }: { onClose: any }) {
   return (
-    <div className="block absolute top-0 right-0 pt-4 pr-4">
+    <div className="promo-button-close-icon-outer">
       <button
         type="button"
-        className="bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-transparent"
+        className="promo-button-close-icon-inner"
         onClick={() => onClose(false)}
       >
         <span className="sr-only">Close</span>
-        <XIcon className="h-6 w-6" aria-hidden="true" />
+        <XIcon className="promo-button-close-icon-size" aria-hidden="true" />
       </button>
     </div>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import React, { Suspense } from 'react';
 import RealEasyLogo from './RealEasyLogo';
 import RangeInput from './RangeInput';
 import TextInput from './TextInput';
-import NameInput from './NameInput';
+import AdTitleInput from './AdTitleInput';
 import { Fragment, useState, useRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XIcon } from './icons';
@@ -169,7 +169,7 @@ export function PromoButton({
   let [fileImage, setFileImage] = useState(undefined);
   let [imageUploadError, setImageUploadError] = useState(false);
   let [targetLinkError, setTargetLinkError] = useState(false);
-  let artistNameInputRef = useRef(null);
+  let adTitleInputRef = useRef(null);
   useScript('https://widget.cloudinary.com/v2.0/global/all.js');
 
   let buttonTextArray;
@@ -255,7 +255,7 @@ export function PromoButton({
             <Transition.Root show={isOpen} as={Fragment}>
               <Dialog
                 as="div"
-                initialFocus={artistNameInputRef}
+                initialFocus={adTitleInputRef}
                 static
                 className="promo-button-dialog-outer"
                 open={isOpen}
@@ -316,7 +316,7 @@ export function PromoButton({
                       <div className="mt-5 sm:mt-6">
                         {!isSubmitted ? (
                           <div>
-                            <NameInput />
+                            <AdTitleInput />
                             <TextInput />
                             <RangeInput />
                             <Suspense fallback={<div>Loading...</div>}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -236,7 +236,7 @@ export function PromoButton({
     }
   };
   return (
-    <div className="animate-ring rounded-md">
+    <div className="rounded-md">
       <button
         onClick={() => {
           setIsOpen(!isOpen);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -180,12 +180,9 @@ export function PromoButton({
   }
   const mainButtonClassName = () => {
     if (typeof shape !== 'string') {
-      return 'promo-button-main';
+      return 'group promo-button-main';
     }
-    if (shape !== 'hero') {
-      return `promo-button-${shape}`;
-    }
-    return `group promo-button-hero`;
+    return `group promo-button-${shape}`;
   };
 
   const submitCampaign = async (event: any) => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}', './src/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: '#4F46E5',
+      },
+    },
   },
   plugins: [require('@tailwindcss/forms')],
   corePlugins: {


### PR DESCRIPTION
This PR adds classes for the actual promo-button css. This should allow users to customize and/or override default classes with or without tailwind. 

In particular, it adds:

- `promo-button-hero`, `promo-button-square`, `promo-button-circle`, `promo-button-simple` to style the outer button container. 
- Customizable class name for the outer button container, i.e. add your own button class via the jsx `shape` prop within your component declaration. For example, 

```jsx
      <PromoButton
        logoSrc=""
        words={['Real', 'Easy', 'Ads']}
        shape="my-custom-outer-button-class"
        email="jason@tincre.com"
        backend="my-backend-route"
      />
 ```

Use it in your global css file:

```css
@tailwind base;
@tailwind components;

@tailwind utilities;

@layer components {
    .promo-button-my-custom-outer-button-class {
      @apply px-36 py-2 // whatever tailwind you want
    }
}
```
- See additional classes available to customize in the [`tailwind.config.js`](/tailwind.config.js) file.

- Custom color `brand` which can be modified in clients' tailwind configuration files, i.e. 
```js
// tailwind.config.js
module.exports = {
  theme: {
    extend: {
      colors: {
        brand: '#4F46E5',
      },
    },
  },

```
